### PR TITLE
[Feat] Dropdown 컴포넌트 개발

### DIFF
--- a/packages/design-system/src/stories/Dropdown/Dropdown.stories.ts
+++ b/packages/design-system/src/stories/Dropdown/Dropdown.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Dropdown, { DropdownProps } from '.';
+
+const meta: Meta<typeof Dropdown> = {
+  title: 'Dropdown',
+  component: Dropdown,
+  argTypes: {
+    title: { control: 'text' },
+    width: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<DropdownProps>;
+
+export const Default: Story = {
+  args: {
+    title: '다른 사이트의 서버 시간',
+    width: 'small',
+  },
+};

--- a/packages/design-system/src/stories/Dropdown/Option.tsx
+++ b/packages/design-system/src/stories/Dropdown/Option.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export type OptionProps = {
+  optionTitle: string;
+  optionLink: string;
+  onClick?: () => void;
+};
+
+const Option = ({ optionTitle, optionLink, onClick }: OptionProps) => {
+  return (
+    <a href={optionLink}>
+      <div className={`w-full h-25% text-xs items-center p-1 cursor-pointer text-black`} onClick={onClick}>
+        {optionTitle}
+      </div>
+      <hr className="border-gold-50" />
+    </a>
+  );
+};
+
+export default Option;

--- a/packages/design-system/src/stories/Dropdown/OptionList.tsx
+++ b/packages/design-system/src/stories/Dropdown/OptionList.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from 'react';
+
+type OptionListProps = {
+  children: ReactNode;
+};
+
+const OptionList = ({ children }: OptionListProps) => {
+  return <div className={`w-full h-full border border-gold-50`}>{children}</div>;
+};
+
+export default OptionList;

--- a/packages/design-system/src/stories/Dropdown/Trigger.tsx
+++ b/packages/design-system/src/stories/Dropdown/Trigger.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useListOpenState } from './hooks/useListOpen';
+
+export type TriggerProps = {
+  title: string;
+};
+
+const Trigger = ({ title, isClicked, handleClick }: TriggerProps & useListOpenState) => {
+  return (
+    <div className={`w-full h-6 border-2 border-gold-50 flex items-center p-1 justify-between`}>
+      <p className="text-xs font-bold">{title}</p>
+      <p className="text-gold-50 text-lg cursor-pointer" onClick={handleClick}>
+        {isClicked ? '▲' : '▼'}
+      </p>
+    </div>
+  );
+};
+
+export default Trigger;

--- a/packages/design-system/src/stories/Dropdown/hooks/useListOpen.ts
+++ b/packages/design-system/src/stories/Dropdown/hooks/useListOpen.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+export type useListOpenState = {
+  isClicked: boolean;
+  handleClick: () => void;
+};
+
+const useListOpen = () => {
+  const [isClicked, setIsClicked] = useState(false);
+
+  const handleClick = () => {
+    setIsClicked(!isClicked);
+  };
+
+  return { isClicked, handleClick };
+};
+
+export default useListOpen;

--- a/packages/design-system/src/stories/Dropdown/index.tsx
+++ b/packages/design-system/src/stories/Dropdown/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Option from './Option';
+import OptionList from './OptionList';
+import Trigger from './Trigger';
+import options from './test';
+import useListOpen from './hooks/useListOpen';
+
+export type DropdownProps = {
+  width: 'small';
+  title: string;
+};
+
+const widthClass = {
+  small: 'w-40',
+};
+
+const Dropdown = ({ title, width }: DropdownProps) => {
+  const { isClicked, handleClick } = useListOpen();
+
+  return (
+    <div className={`${widthClass[width]}`}>
+      <Trigger title={title} isClicked={isClicked} handleClick={handleClick} />
+      {isClicked ? (
+        <OptionList>
+          {options.map(option => (
+            <Option key={option.id} optionTitle={option.title} optionLink={option.link} />
+          ))}
+        </OptionList>
+      ) : (
+        ''
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/packages/design-system/src/stories/Dropdown/test.ts
+++ b/packages/design-system/src/stories/Dropdown/test.ts
@@ -1,0 +1,8 @@
+const options = [
+  { id: 1, title: '인터파크 티켓', link: '' },
+  { id: 2, title: 'YES24 티켓', link: '' },
+  { id: 3, title: '멜론 티켓', link: '' },
+  { id: 4, title: '직접 입력', link: '' },
+];
+
+export default options;


### PR DESCRIPTION
## 🔥관련 이슈

- #17 

## :grin:주요 변경 사항

- Dropdown 컴포넌트 합성 컴포넌트 패턴으로 개발

## :pencil:배운 점

### Dropdown

- **합성 컴포넌트**로 만드는 이유: 복잡한 UI 구조를 간결하고, 유지보수가 용이하게 구성하기 위해서다.
- span과 p 태그 차이:
    - span: 일반적으로 텍스트의 색, 크기, 좌우 간격을 조절하는데 사용하고, **인라인 요소**다.
    - p: 문단을 기재할 때 사용하며, 줄바꿈을 할 수 있다. **블록 요소**로 한 줄 전체 차지
- rem과 px의 차이
    - rem: html의 기본 font-size를 기준으로 상대적인 크기를 지정한다.
    - px: 고정 크기
- 공식문서를 봤을 때, tailwind는 props를 받아서 동적으로 클래스를 생성하면 안된다.
    - 대신 빌드 타임에 정적으로 탐지할 수 있게 props를 객체로 맵핑해 사용할 수 있다.
    
    ```jsx
    export type DropdownProps = {
      width: 'small';
      title: string;
    };
    
    const widthClass = {
      small: 'w-40',
    };
    
    const Dropdown = ({ title, width }: DropdownProps) => {
      const { isClicked, handleClick } = useListOpen();
    
      return (
        <div className={`${widthClass[width]}`}>
    ```
    
- 참고: [https://medium.com/waiker/합성컴포넌트와-headless-를-이용해서-재사용-가능한-컴포넌트-만들기-afbb92adcfab](https://medium.com/waiker/%ED%95%A9%EC%84%B1%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EC%99%80-headless-%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%9E%AC%EC%82%AC%EC%9A%A9-%EA%B0%80%EB%8A%A5%ED%95%9C-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8-%EB%A7%8C%EB%93%A4%EA%B8%B0-afbb92adcfab)

## 📄스크린샷
![Dropdown](https://github.com/user-attachments/assets/5f9e5bf0-a914-4742-92f1-3bed830c637f)
